### PR TITLE
feat: require at least one item (instead of two) in AdaptiveTabView/A…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.0.4
+
+### api
+- feat: allow end-user to render an `AdaptiveTabView`/`AdaptiveNavigationView` 
+  with a minimum of one item (instead of two). ([#1])
+
+[#1]: https://github.com/Abbas1Hussein/adp_desktop/issues/1
+
 ## 0.0.3
 
 ### docs

--- a/lib/src/components/navigation/navigation_view/navigation_sidebar.dart
+++ b/lib/src/components/navigation/navigation_view/navigation_sidebar.dart
@@ -15,7 +15,7 @@ import '../../../core/common/construct/model.dart';
 class AdaptiveNavigationSidebar extends CoreModel<NavigationPane, Sidebar> {
   /// Creates a adaptive nav sidebar
   ///
-  /// [items] must have at least 2 items
+  /// [items] must have at least 1 item
   ///
   /// [currentIndex] must be in the range of 0 to [items.length]
   const AdaptiveNavigationSidebar({
@@ -33,7 +33,7 @@ class AdaptiveNavigationSidebar extends CoreModel<NavigationPane, Sidebar> {
     this.backgroundColor,
     this.properties,
     this.items = const [],
-  })  : assert(items.length >= 2),
+  })  : assert(items.length >= 1),
         assert(currentIndex >= 0 && currentIndex < items.length);
 
   /// The current selected index. This must be in the range of 0 to [items.length].

--- a/lib/src/components/navigation/tab_view/tab_view.dart
+++ b/lib/src/components/navigation/tab_view/tab_view.dart
@@ -34,7 +34,7 @@ class AdaptiveTabView extends CoreAdaptiveComponent<TabViewWindowsProperty,
   /// You can provide specific [properties] for each platform using `TabViewWindowsProperty`
   /// and `TabViewMacosProperty` respectively.
   ///
-  /// - [tabs] must have at least 2 items and must be equal to the length of [children].
+  /// - [tabs] must have at least 1 item and must be equal to the length of [children].
   /// - [currentIndex] must be in the range of 0 to [items.length]
   const AdaptiveTabView({
     super.key,
@@ -54,7 +54,7 @@ class AdaptiveTabView extends CoreAdaptiveComponent<TabViewWindowsProperty,
     this.contentPadding = kContentPadding,
     required this.tabs,
     required this.children,
-  })  : assert(tabs.length >= 2),
+  })  : assert(tabs.length >= 1),
         assert(
           tabs.length == children.length,
           '\nTabs and children lists must have the same length.\n'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: adp_desktop
 description: Implements AdaptiveUi for Windows and Macos in Flutter.
-version: 0.0.3
+version: 0.0.4
 homepage: https://github.com/Abbas1Hussein/adp_desktop/#/
 repository: https://github.com/Abbas1Hussein/adp_desktop
 issue_tracker: https://github.com/Abbas1Hussein/adp_desktop/issues


### PR DESCRIPTION
## 📝 Description

- allow end-user to render a tab view with a minimum of one tab (instead of two). Same for the navigation sidebar.
- update CHANGELOG.
- bump version to 0.0.4 (was 0.0.3).

## 🧩 Type of Change
- [x] ✨ Feature — New functionality without breaking existing features
- [ ] 🛠️ Bug Fix — Fixes an issue without altering current behavior
- [ ] 🧹 Refactor — Code improvements without behavior change
- [ ] ❌ Breaking Change — Modifies existing functionality
- [ ] 🧪 Tests — Added or updated tests
- [ ] 📝 Documentation — Updated or added documentation
- [x] 🗑️ Chore — Maintenance or minor updates
- [ ] ✅ Build/Config — Build or configuration updates

---

## ✅ Checklist
Please confirm the following before submitting:

- [x] I have tested these changes locally
- [x] I have incremented the **package version** as appropriate
- [x] I have updated **CHANGELOG.md** with my changes
- [x] I have added or updated relevant **documentation**
- [x] I have run **“Organize Imports”** on all changed files
- [x] I have resolved all **analyzer warnings** as best I could
- [x] The code follows the project’s **style and conventions**

---

## 🧠 Additional Notes (Optional)
Closes #1