### PR TITLE
fix: improve DefaultsPlatformManager initialization checks and error …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.0.5
+
+### fix
+- refactor: add `DefaultsPlatformManager.ensureInitialized()` to centralize initialization checks.
+- fix: improve error messages when accessing `targetPlatform` before initialization.
+
 ## 0.0.4
 
 ### api

--- a/lib/src/components/app/app.dart
+++ b/lib/src/components/app/app.dart
@@ -324,6 +324,12 @@ class AdpApp
   bool get usesRouter => routerDelegate != null || routerConfig != null;
 
   @override
+  Widget build(BuildContext context) {
+    DefaultsPlatformManager.ensureInitialized();
+    return super.build(context);
+  }
+
+  @override
   Widget windows(BuildContext context, [AppWindowsProperty? property]) {
     if (usesRouter) {
       return FluentApp.router(

--- a/lib/src/core/common/platform_manager.dart
+++ b/lib/src/core/common/platform_manager.dart
@@ -44,7 +44,23 @@ class DefaultsPlatformManager {
 
   /// Initializes the DefaultsPlatformManager with the specified parameters.
   ///
-  /// - [isTesting] is only for testing.
+  /// - [targetPlatform] Use DesktopTargetPlatform.<value> for the application:
+  ///
+  /// Example usage:
+  /// ```dart
+  /// void main() async {
+  ///   DefaultsPlatformManager.initialize(
+  ///     DesktopTargetPlatform.windows,
+  ///     isDebugging: true,
+  ///   );
+  ///   runApp(const App());
+  /// }
+  /// ```
+  ///
+  /// - [targetLinux] is the target Linux platform or defaults to [targetPlatform] if not specified.
+  /// - [targetWeb] is the target web platform or defaults to [targetPlatform] if not specified.
+  /// - [isDebugging] is the debugging status for the application, If set to false,
+  /// the [targetPlatform] parameter will be ignored, and the specific widget behavior will depend on the base platform.
   ///
   /// Throws an error if the manager is already initialized.
   factory DefaultsPlatformManager.initialize({
@@ -83,17 +99,24 @@ class DefaultsPlatformManager {
   ///
   /// Throws an error if the manager is not initialized.
   static DefaultsPlatformManager get instance {
+    ensureInitialized();
+
+    return _instance!;
+  }
+
+  static DefaultsPlatformManager? _instance;
+
+  /// Ensures that the manager has been initialized.
+  ///
+  /// Throws an error if the manager is not initialized.
+  static void ensureInitialized() {
     if (!isInitialized) {
       throw StateError(
         'DefaultsPlatformManager has not been initialized.\n'
         'Call DefaultsPlatformManager.initialize() before accessing instance.',
       );
     }
-
-    return _instance!;
   }
 
   static bool get isInitialized => _instance != null;
-
-  static DefaultsPlatformManager? _instance;
 }

--- a/lib/src/core/common/platform_ruining.dart
+++ b/lib/src/core/common/platform_ruining.dart
@@ -87,9 +87,8 @@ abstract final class PlatformRuining {
   /// Throws an error if [DefaultsPlatformManager] is not initialized.
   static DesktopTargetPlatform get targetPlatform {
     if (!DefaultsPlatformManager.isInitialized) {
-      throw ArgumentError(
-        'Do not use PlatformRuining.targetPlatform before or inside DefaultsPlatformManager.initialize(). '
-        'Use DesktopTargetPlatform.<value> instead.',
+      throw StateError(
+        'Do not use PlatformRuining.targetPlatform before or inside DefaultsPlatformManager.initialize().'
       );
     }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: adp_desktop
 description: Implements AdaptiveUi for Windows and Macos in Flutter.
-version: 0.0.4
+version: 0.0.5
 homepage: https://github.com/Abbas1Hussein/adp_desktop/#/
 repository: https://github.com/Abbas1Hussein/adp_desktop
 issue_tracker: https://github.com/Abbas1Hussein/adp_desktop/issues


### PR DESCRIPTION
## 📝 Description
- **Previous behavior:** Accessing `targetPlatform` before calling `DefaultsPlatformManager.initialize()` could throw unclear runtime errors or lead to misuse.

- **New behavior:** Added a centralized `ensureInitialized()` method to verify initialization, error messages for accessing `instance` or `targetPlatform` before initialization are now clearer and more descriptive, and the initialization check was repeated in multiple places.
 
- **Why this change was needed:** To prevent runtime errors and improve developer experience by providing clear guidance when `DefaultsPlatformManager` is accessed before being initialized.


## 🧩 Type of Change
- [x] ✨ Feature — New functionality without breaking existing features
- [ ] 🛠️ Bug Fix — Fixes an issue without altering current behavior
- [x] 🧹 Refactor — Code improvements without behavior change
- [ ] ❌ Breaking Change — Modifies existing functionality
- [ ] 🧪 Tests — Added or updated tests
- [x] 📝 Documentation — Updated or added documentation
- [x] 🗑️ Chore — Maintenance or minor updates
- [ ] ✅ Build/Config — Build or configuration updates

## ✅ Checklist
- [x] I have tested these changes locally
- [x] I have incremented the **package version** as appropriate
- [x] I have updated **CHANGELOG.md** with my changes
- [x] I have added or updated relevant **documentation**
- [x] I have run **“Organize Imports”** on all changed files
- [x] I have resolved all **analyzer warnings** as best I could
- [x] The code follows the project’s **style and conventions**


